### PR TITLE
Fix issue with dimmer to small

### DIFF
--- a/libs/webgui/pilight.css
+++ b/libs/webgui/pilight.css
@@ -40,7 +40,7 @@
 }
 
 .ui-li-static {
-	height: 27px;
+	min-height: 27px;
 	padding: 5px 0px 5px 0px;
 }
 
@@ -348,11 +348,6 @@ div.media_icon.song {
 ul.ui-listview li.switch div.name {
         padding-right: 95px;
         white-space: normal;
-}
-
-.ui-li-static {
-        height: auto;
-        min-height: 27px;
 }
 
 .weather_values {


### PR DESCRIPTION
This addresses the issue that dimmers are not high enough as mentioned here:
https://github.com/pilight/pilight/commit/892289638dfa4edb6934e4c05a6bcb3ca16ad3ec#commitcomment-25587958